### PR TITLE
Add Dockerfile for setting up Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Use a Node.js base image
+FROM node:18.7.0
+
+# Install curl
+RUN apt-get update && apt-get install -y curl
+
+# Install yarn and pm2
+RUN npm install -g pm2
+
+# Install pm2-logrotate
+RUN pm2 install pm2-logrotate
+
+# Set the working directory
+WORKDIR /app
+
+# Clone the code repository
+RUN git clone https://github.com/farcasterxyz/hubble.git .
+
+# Checkout the stable release
+RUN git checkout @farcaster/hubble@1.2.0
+
+# Build hubble
+RUN yarn install && yarn build
+
+COPY start.sh /app/apps/hubble/start.sh
+RUN chmod +x /app/apps/hubble/start.sh
+
+# Create an identity
+RUN cd apps/hubble/ && yarn identity create
+
+# Expose the required ports
+EXPOSE 2282
+
+ARG ALCHEMY_GOERLI_URL
+ENV ALCHEMY_GOERLI_URL=$ALCHEMY_GOERLI_URL
+
+ARG HUBBLE_PEERS
+ENV HUBBLE_PEERS=$HUBBLE_PEERS
+
+WORKDIR /app/apps/hubble
+
+# Set the command to run when the container starts
+CMD ["sh", "-c", "/app/apps/hubble/start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+APPLICATION_NAME ?= hubble
+REGION ?= us-east-1
+
+login: 
+		aws --profile personal ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+
+create_repo:
+		aws --profile personal ecr create-repository --repository-name ${APPLICATION_NAME} --image-scanning-configuration scanOnPush=true
+
+build_local:
+		docker build --build-arg ALCHEMY_GOERLI_URL=${ALCHEMY_GOERLI_URL} --build-arg HUBBLE_PEERS=${HUBBLE_PEERS} --tag ${APPLICATION_NAME} .
+
+run_local:
+		docker run -p 2282:2282 -p 2283:2283 -d ${APPLICATION_NAME}
+
+docker_build_and_run_local: build_local run_local
+
+build:
+		docker build --platform linux/amd64 --build-arg ALCHEMY_GOERLI_URL=${ALCHEMY_GOERLI_URL} --build-arg HUBBLE_PEERS=${HUBBLE_PEERS} -t ${APPLICATION_NAME} .
+
+tag:
+		docker tag ${APPLICATION_NAME} ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/${APPLICATION_NAME}:latest
+
+push:
+		docker push ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/${APPLICATION_NAME}:latest
+
+docker_build_and_push: login build tag push

--- a/README.md
+++ b/README.md
@@ -1,1 +1,137 @@
 # farcaster-hub
+
+# Welcome
+
+These instructions will help you setup a Farcaster hub either on testnet or mainnet. They are based on [these instructions](https://warpcast.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042) from Merkle
+
+NOTE: To move to mainnet, you'll want to run on testnet first and make sure you're syncing. Read this before trying mainnet: https://warpcast.notion.site/warpcast/Mainnet-Hubs-dc2ff6d528f64992afe03797b61dec32
+
+Each step has a Makefile-based version (simpler) or the equivalent manual commands
+
+# 0. Initial setup
+
+1. [Install docker](https://docs.docker.com/install/)
+2. [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+3. Clone this repo: `git clone https://github.com/bitwise-invest/farcaster-hub.git` and enter the folder `cd farcaster-hub`
+
+# 1. Run Hub Locally (optional - the Merkle instructions don't talk about running locally)
+
+```
+make docker_build_and_run_local
+```
+
+If you want, you can execute these [manually](#run-locally---manual-commands)
+
+# 2. Export Local Variables
+
+```
+export ALCHEMY_GOERLI_URL={INSERT_ALCHEMY_URL}
+export AWS_ACCOUNT_ID={INSERT_AWS_ACCOUNT_ID}
+```
+
+If you want to run testnet:
+```
+export HUBBLE_PEERS=/dns/testnet1.farcaster.xyz/tcp/2282
+```
+or mainnet:
+```
+export HUBBLE_PEERS=/dns/hoyt.farcaster.xyz/tcp/2282
+```
+
+# 3. Push Docker Image to ECR
+
+## Create ECR repo (FIRST TIME ONLY):
+
+```
+make login && make create_repo
+```
+
+If you want, you can execute these [manually](#create-ecr-repo---manual-commands)
+
+## Push to ECR Repo:
+
+```
+make docker_build_and_push
+```
+
+If you want, you can execute these [manually](#push-docker-image-to-ecr---manual-commands)
+
+# 4. Terraform infra on AWS:
+
+1. In `variables.tf`, set the "key_name" to your `key_name.pem` file (or [create a new one](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html))
+
+2. 
+```
+terraform init
+```
+3. Plan: dry-run that will show you what AWS changes will be made
+```
+terraform plan
+```
+4. Apply: actualy makes the AWS changes
+```
+terraform apply
+```
+
+To destroy:
+
+```
+terraform destroy
+```
+
+---
+
+# Additional Docker Setup or Debugging Commands
+
+- Build docker images: `docker build . -t hubble`
+- Run docker image: `docker run -p 2282:2282 -p 2283:2283 -d hubble`
+- Debugging
+  - List containers (with container id) - `docker ps`
+  - Show logs - `docker logs [container id]`
+- To enter the machine: `docker exec -it [container id] /bin/bash`
+  - If you need to exit, command is `cmd+z` I believe
+- Kill docker image: `docker kill [container id]`
+
+---
+
+# Manual instructions
+
+## Run locally - manual commands
+
+1. 
+```
+docker build --build-arg ALCHEMY_GOERLI_URL=$ALCHEMY_GOERLI_URL --build-arg HUBBLE_PEERS=$HUBBLE_PEERS -t hubble .
+docker run -p 2282:2282 -p 2283:2283 -d hubble
+```
+
+## Create ECR repo - manual commands
+
+1. Authenticate
+```
+aws --profile personal ecr get-login-password  --region us-east-1 | docker login --username AWS --password-stdin $$AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
+```
+2. Create ECR repository 
+```
+aws --profile personal ecr create-repository --repository-name hubble --image-scanning-configuration scanOnPush=true
+```
+
+##  Push Docker Image to ECR - manual commands
+
+1. Authenticate
+```
+aws --profile personal ecr get-login-password  --region us-east-1 | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
+```
+
+2. Build
+```
+docker build --platform linux/amd64 --build-arg ALCHEMY_GOERLI_URL=$ALCHEMY_GOERLI_URL -t hubble .
+```
+
+3. Tag
+```
+docker tag hubble $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/hubble:latest
+```
+4. Push
+```
+docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/hubble:latest
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,187 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+data "aws_caller_identity" "current" {}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+resource "aws_vpc" "vpc_1" {
+  cidr_block = "172.31.0.0/16"
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "172.31.0.0/20"
+  availability_zone       = "${var.aws_availability_zone}" # Change this to your desired availability zone
+  map_public_ip_on_launch = true
+}
+
+resource "aws_security_group" "hub_security_group" {
+  name        = "launch-wizard"
+  description = "launch-wizard created 2023-04-14T20:55:05.027Z"
+  vpc_id      = aws_vpc.vpc_1.id
+
+  egress = [
+    {
+      cidr_blocks      = [
+          "0.0.0.0/0",
+      ]
+      from_port        = 2282
+      to_port          = 2283
+      protocol         = "tcp"
+      description      = ""
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+    {
+      cidr_blocks      = [
+          "0.0.0.0/0",
+      ]
+      from_port        = 80
+      to_port          = 80
+      protocol         = "tcp"
+      description      = ""
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+    {
+      cidr_blocks      = [
+          "0.0.0.0/0",
+      ]
+      from_port        = 443
+      to_port          = 443
+      protocol         = "tcp"
+      description      = ""
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+  ]
+
+  ingress = [
+    {
+      cidr_blocks      = [
+          "0.0.0.0/0",
+      ]
+      from_port        = 2282
+      to_port          = 2283
+      protocol         = "tcp"
+      self             = false
+      description      = ""
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+    {
+      cidr_blocks      = [
+          "0.0.0.0/0",
+      ]
+      from_port        = 22
+      to_port          = 22
+      protocol         = "tcp"
+      self             = false
+      description      = ""
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    },
+  ]
+
+  tags = {
+    Name = "hub_security_group"
+  }
+}
+
+resource "aws_eip" "hubble_eip" {
+  vpc = true
+}
+
+# Create an IAM role for EC2 instances with the necessary permissions to access ECR
+resource "aws_iam_role" "ec2_instance_role" {
+  name = "ec2_instance_role"
+  
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach an IAM policy to the role that allows access to ECR repositories
+resource "aws_iam_role_policy_attachment" "ecr_access_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.ec2_instance_role.name
+}
+
+# Create an EC2 instance profile and attach the IAM role to it
+resource "aws_iam_instance_profile" "ec2_instance_profile" {
+  name = "ec2_instance_profile"
+  role = aws_iam_role.ec2_instance_role.name
+}
+
+resource "aws_instance" "hub_instance" {
+  ami           = "ami-007855ac798b5175e" # This is the Ubuntu Server 22.04 LTS 64-bit (x86) AMI ID
+  availability_zone = "us-east-1d"
+  instance_type = "m5.large"
+  associate_public_ip_address = false
+
+  vpc_security_group_ids = [aws_security_group.hub_security_group.id]
+  subnet_id = aws_subnet.subnet_1.id
+
+  iam_instance_profile = aws_iam_instance_profile.ec2_instance_profile.name
+
+  key_name = "${var.key_name}"
+
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get update
+              sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+              echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+              sudo apt-get update
+              sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+              sudo systemctl start docker
+              sudo apt-get install awscli -y
+              aws ecr get-login-password --region us-east-1 | sudo docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.us-east-1.amazonaws.com
+              sudo docker pull ${data.aws_caller_identity.current.account_id}.dkr.ecr.us-east-1.amazonaws.com/hubble:latest # Replace with the name of your Docker image
+              sudo docker run -p 2282:2282 -p 2283:2283 -d ${data.aws_caller_identity.current.account_id}.dkr.ecr.us-east-1.amazonaws.com/hubble:latest # Add any additional flags or options you need for your container
+              EOF
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name = "FC Hub"
+  }
+}
+
+resource "aws_eip_association" "hubble_eip_association" {
+  instance_id   = aws_instance.hub_instance.id
+  public_ip     = aws_eip.hubble_eip.public_ip
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pm2-runtime start "yarn start -e ${ALCHEMY_GOERLI_URL} -b ${HUBBLE_PEERS} -n 2" --name hubble

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  description = "The AWS region to create things in."
+  default     = "us-east-1"
+}
+
+variable "aws_availability_zone" {
+  description = "The AWS availability zone."
+  default     = "us-east-1d"
+}
+
+variable "key_name" {
+  description = "The key pair name to login to your EC2 instance"
+  default     = "samplekey" # Set to your keyname
+}


### PR DESCRIPTION
This PR adds instructions for setting up a Hub following the instructions:

https://warpcast.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042
https://warpcast.notion.site/warpcast/Mainnet-Hubs-dc2ff6d528f64992afe03797b61dec32

The `README.md` has step-by-step instructions. The idea is that deploying to AWS can be a couple commands on the terminal instead of a long set of instructions